### PR TITLE
Multilingual Feature -> Map course outline to dashboard Styles

### DIFF
--- a/edx-platform/wikilearn/cms/static/sass/partials/cms/theme/_extras.scss
+++ b/edx-platform/wikilearn/cms/static/sass/partials/cms/theme/_extras.scss
@@ -1,0 +1,13 @@
+// Extra rules needed for the Studio red theme
+//
+// Note: the red theme doesn't provide any additional rules.
+//
+// The _extras.scss file is imported after all other rules by
+// the Studio Sass. For your own theme, you can override this file
+// to add any custom rules that you need. You can also import
+// partials directly into this file so that you can break your
+// rules into modular pieces.
+
+@import "variable";
+@import "./spinner";
+@import "./translations";

--- a/edx-platform/wikilearn/cms/static/sass/partials/cms/theme/_spinner.scss
+++ b/edx-platform/wikilearn/cms/static/sass/partials/cms/theme/_spinner.scss
@@ -1,0 +1,53 @@
+.spinner {
+    --animation-duration: 1000ms;
+    width: 60px;
+    height: 60px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 4px;
+    margin: 0 auto;
+
+    &.center-in-screen {
+        background: #fff;
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-100%, -100%);
+        z-index: 9;
+    }
+
+    .spinner-item {
+        height: 40%;
+        background-color: $theme-blue;
+        opacity: 0.8;
+        width: calc(60px / 13);
+        animation: spinner var(--animation-duration) ease-in-out infinite;
+    }
+
+    .spinner-item:nth-child(2) {
+        animation-delay: calc(var(--animation-duration) / 10);
+    }
+
+    .spinner-item:nth-child(3) {
+        animation-delay: calc(var(--animation-duration) / 10 * 2);
+    }
+
+    .spinner-item:nth-child(4) {
+        animation-delay: calc(var(--animation-duration) / 10 * 3);
+    }
+
+    .spinner-item:nth-child(5) {
+        animation-delay: calc(var(--animation-duration) / 10 * 4);
+    }
+}
+
+@keyframes spinner {
+    25% {
+        transform: scaleY(2);
+    }
+
+    50% {
+        transform: scaleY(1);
+    }
+}

--- a/edx-platform/wikilearn/cms/static/sass/partials/cms/theme/_translations.scss
+++ b/edx-platform/wikilearn/cms/static/sass/partials/cms/theme/_translations.scss
@@ -1,0 +1,154 @@
+html { height: 100%; }
+.translations {
+  box-sizing: border-box;
+  padding: 50px 20px;
+  min-height: calc( 100vh - 280px);
+
+  img {
+    visibility: hidden;
+  }
+
+  * {
+    &,
+    &:after,
+    &:before {
+      box-sizing: border-box;
+    }
+  }
+
+  .translation-header,
+  .translation-languages {
+    display: flex;
+    padding-bottom: 20px;
+
+    .course-select {
+      width: 100%;
+    }
+
+    .col {
+      flex: 0 0 50%;
+      max-width: 50%;
+      padding: 0 25px;
+
+      > div {
+        max-width: 290px;
+      }
+    }
+  }
+
+  .translation-frame {
+    background: #fff;
+    padding: 20px 5px;
+    border-radius: 5px;
+  }
+}
+
+.sections {
+
+  .col {
+    padding: 8px $indent;
+    flex: 0 0 50%;
+    font-size: 15px;
+    position: relative;
+
+    .title {
+      font-size: 16px;
+    }
+
+    &:first-child {
+      border-right: 1px solid #ccc;
+    }
+  }
+
+  .header { cursor: pointer; }
+
+  .header,
+  .translation-body,
+  .translation-title {
+    display: flex;
+
+    &:hover {
+      > .col {
+        background: #eee;
+      }
+    }
+
+    .fa {
+      top: 14px;
+      left: 5px;
+      position: absolute;
+      font-size: 11px;
+      transition: transform .3s ease;
+    }
+  }
+
+  .translation-body {
+    font-size: 14px;
+
+    * {
+      font-size: inherit !important;
+    }
+
+    ul, ol {
+      margin: 2rem 0;
+      padding-left: 2rem;
+      list-style: inherit;
+    }
+
+    ol {
+      list-style: auto;
+    }
+
+    p {
+      margin: 2rem 0;
+    }
+  }
+
+  .body {
+
+    .col {
+      padding-left: $indent*2;
+
+      .fa {
+        left: $indent*2-15;
+      }
+    }
+
+    .body {
+
+      .col {
+        padding-left: $indent*3;
+
+        .fa {
+          left: $indent*3-15;
+        }
+      }
+    }
+  }
+}
+
+.collapsed {
+
+  > .header {
+
+    .fa {
+      transform: rotate(-90deg);
+    }
+  }
+
+  > .body {
+    display: none;
+  }
+}
+
+.course-select {
+  background-color: #f2f2f2;
+  background-image: -webkit-linear-gradient(#f2f2f2,#fff);
+  background-image: linear-gradient(#f2f2f2,#fff);
+  padding: 6px 8px 8px;
+  border: 1px solid #b2b2b2;
+  border-radius: 2px;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, .1);
+  color: #4c4c4c;
+  outline: 0;
+}

--- a/edx-platform/wikilearn/cms/static/sass/partials/cms/theme/_variable.scss
+++ b/edx-platform/wikilearn/cms/static/sass/partials/cms/theme/_variable.scss
@@ -1,0 +1,2 @@
+$indent:            25px;
+$theme-blue:      #36c;


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Map course outline to the translation page

<img width="1371" alt="image" src="https://user-images.githubusercontent.com/51116673/161262916-53d4231f-8005-4f00-adc8-9bab62c25abb.png">

## Description
Displays the base and translated course versions outline and its content.
Url to the page <YourStudioUrl>/meta_translations/

